### PR TITLE
update verbose.js to show total duration

### DIFF
--- a/lib/reporters/verbose.js
+++ b/lib/reporters/verbose.js
@@ -95,7 +95,11 @@ class VerboseReporter {
 		].filter(Boolean);
 
 		if (lines.length > 0) {
-			lines[0] += ' ' + chalk.gray.dim('[' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
+			var duration = 0;
+            		runStatus.tests.forEach( test => {
+                		duration += test.duration;
+            		});
+		        lines[0] += ' ' + chalk.gray.dim('[took: ' + prettyMs(duration) + ' at ' + new Date().toLocaleTimeString('en-US', {hour12: false}) + ']');
 			output += lines.join('\n') + '\n';
 		}
 


### PR DESCRIPTION
the way verbose was showing a timestamp, was very confusing.
I don't care much when the tests run, I want to know how much time it took.

now we have both
  21 tests passed [took: 1.6s at 14:45:18]

I think this is clearer

<!--

Read the [contributing guidelines](https://github.com/avajs/ava/blob/master/contributing.md). We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it. If this fixes an open issue, link to it in the following way: `Fixes #321`. New features and bug fixes should come with tests.

-->
